### PR TITLE
Adding the ability for users to create their own api keys

### DIFF
--- a/core/API_KEY_USAGE.md
+++ b/core/API_KEY_USAGE.md
@@ -1,6 +1,6 @@
 # API Key Authentication
 
-This document explains how to get and use an API key from web UI.
+This document explains how to get and use an API key for the NewsAgent API.
 
 ## Obtaining an API Key
 
@@ -23,7 +23,7 @@ X-API-Key: your-api-key
 Example using curl:
 ```bash
 curl -X POST \
-  http://localhost:8000/query \
+  http://localhost:8001/query \
   -H 'Content-Type: application/json' \
   -H 'X-API-Key: your-api-key' \
   -d '{"body": "Your query text here"}'
@@ -50,7 +50,7 @@ You can also manage your API keys programmatically:
 To create a new API key:
 
 ```
-POST /api-keys
+POST http://localhost:8001/api-keys
 ```
 
 Request body:
@@ -58,6 +58,15 @@ Request body:
 {
   "name": "My New API Key"
 }
+```
+
+Example using curl:
+```bash
+curl -X POST \
+  http://localhost:8001/api-keys \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: your-existing-api-key' \
+  -d '{"name": "My New API Key"}'
 ```
 
 Response:
@@ -72,14 +81,21 @@ Response:
 }
 ```
 
-Note: This endpoint requires authentication with an existing API key.
+Note: This endpoint requires authentication with an existing API key. You must include your existing API key in the `X-API-Key` header.
 
 #### Listing API Keys
 
 To list all your API keys:
 
 ```
-GET /api-keys
+GET http://localhost:8001/api-keys
+```
+
+Example using curl:
+```bash
+curl -X GET \
+  http://localhost:8001/api-keys \
+  -H 'X-API-Key: your-existing-api-key'
 ```
 
 Response:
@@ -96,12 +112,21 @@ Response:
 ]
 ```
 
+Note: This endpoint requires authentication with an existing API key.
+
 #### Deleting an API Key
 
 To delete an API key:
 
 ```
-DELETE /api-keys/{api_key_id}
+DELETE http://localhost:8001/api-keys/{api_key_id}
+```
+
+Example using curl:
+```bash
+curl -X DELETE \
+  http://localhost:8001/api-keys/2 \
+  -H 'X-API-Key: your-existing-api-key'
 ```
 
 Response:
@@ -110,6 +135,8 @@ Response:
   "message": "API key deleted successfully"
 }
 ```
+
+Note: This endpoint requires authentication with an existing API key. Replace `{api_key_id}` with the ID of the API key you want to delete.
 
 ## Security Considerations
 

--- a/core/API_KEY_USAGE.md
+++ b/core/API_KEY_USAGE.md
@@ -4,9 +4,13 @@ This document explains how to get and use an API key from web UI.
 
 ## Obtaining an API Key
 
-API keys are automatically generated when you use the web interface to search for news claims. The system will create an API key for your account if you don't already have one.
+There are several ways to obtain an API key:
 
-Alternatively, administrators can create API keys for users through the Django admin interface.
+1. **Automatic Generation**: API keys are automatically generated when you use the web interface to search for news claims. The system will create an API key for your account if you don't already have one.
+
+2. **User-Created Keys**: You can create your own API keys through the "My API Keys" page. This allows you to create multiple keys for different applications or services.
+
+3. **Admin Creation**: Administrators can create API keys for users through the Django admin interface.
 
 ## Using an API Key
 
@@ -29,7 +33,19 @@ When you use an API key, the system tracks its usage by updating the `last_used_
 
 ## Managing API Keys
 
-### Listing API Keys
+### Web Interface
+
+You can manage your API keys through the web interface:
+
+1. **Viewing Keys**: Navigate to the "My API Keys" page to see all your API keys.
+2. **Creating Keys**: Click the "Create New API Key" button to generate a new API key.
+3. **Deleting Keys**: Click the "Delete" button next to an API key to remove it.
+
+### API Endpoints
+
+You can also manage your API keys programmatically:
+
+#### Listing API Keys
 
 To list all your API keys:
 
@@ -51,7 +67,7 @@ Response:
 ]
 ```
 
-### Deleting an API Key
+#### Deleting an API Key
 
 To delete an API key:
 

--- a/core/API_KEY_USAGE.md
+++ b/core/API_KEY_USAGE.md
@@ -8,7 +8,7 @@ There are several ways to obtain an API key:
 
 1. **Automatic Generation**: API keys are automatically generated when you use the web interface to search for news claims. The system will create an API key for your account if you don't already have one.
 
-2. **User-Created Keys**: You can create your own API keys through the "My API Keys" page. This allows you to create multiple keys for different applications or services.
+2. **User-Created Keys**: You can create your own API keys through the "API Keys" page. This allows you to create multiple keys for different applications or services.
 
 3. **Admin Creation**: Administrators can create API keys for users through the Django admin interface.
 
@@ -37,13 +37,42 @@ When you use an API key, the system tracks its usage by updating the `last_used_
 
 You can manage your API keys through the web interface:
 
-1. **Viewing Keys**: Navigate to the "My API Keys" page to see all your API keys.
+1. **Viewing Keys**: Navigate to the "API Keys" page to see all your API keys.
 2. **Creating Keys**: Click the "Create New API Key" button to generate a new API key.
 3. **Deleting Keys**: Click the "Delete" button next to an API key to remove it.
 
 ### API Endpoints
 
 You can also manage your API keys programmatically:
+
+#### Creating API Keys
+
+To create a new API key:
+
+```
+POST /api-keys
+```
+
+Request body:
+```json
+{
+  "name": "My New API Key"
+}
+```
+
+Response:
+```json
+{
+  "id": 2,
+  "name": "My New API Key",
+  "key": "generated-api-key",
+  "created_at": "2023-01-03T00:00:00.000Z",
+  "last_used_at": null,
+  "is_active": true
+}
+```
+
+Note: This endpoint requires authentication with an existing API key.
 
 #### Listing API Keys
 

--- a/django/user_info/static/css/hamburger-menu.css
+++ b/django/user_info/static/css/hamburger-menu.css
@@ -1,0 +1,100 @@
+/* Hamburger Menu Styles */
+.hamburger-menu {
+  position: absolute;
+  top: 85px;
+  right: 85px;
+  z-index: 1000;
+  cursor: pointer;
+}
+
+.hamburger-icon {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 30px;
+  height: 21px;
+  transition: all 0.3s ease-in-out;
+}
+
+.hamburger-icon span {
+  display: block;
+  height: 3px;
+  width: 100%;
+  background-color: white;
+  border-radius: 3px;
+  transition: all 0.3s ease-in-out;
+}
+
+.menu-items {
+  position: fixed;
+  top: 0;
+  right: -250px;
+  width: 250px;
+  height: 100vh;
+  background-color: rgba(40, 40, 40, 0.95);
+  padding-top: 60px;
+  transition: right 0.3s ease-in-out;
+  z-index: 999;
+  box-shadow: -5px 0 15px rgba(0, 0, 0, 0.3);
+}
+
+.menu-items.active {
+  right: 0;
+}
+
+.menu-items a {
+  display: block;
+  padding: 15px 25px;
+  color: white;
+  text-decoration: none;
+  font-size: 18px;
+  transition: background-color 0.3s;
+}
+
+.menu-items a:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Close button at bottom of menu */
+.menu-close-btn {
+  position: absolute;
+  bottom: 20px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  padding: 10px;
+  margin: 0 25px;
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background-color 0.3s;
+}
+
+.menu-close-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Hide hamburger icon when menu is active */
+.hamburger-icon.active {
+  opacity: 0;
+  visibility: hidden;
+}
+
+/* Overlay when menu is active */
+.menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 998;
+  display: none;
+}
+
+.menu-overlay.active {
+  display: block;
+}

--- a/django/user_info/static/js/hamburger-menu.js
+++ b/django/user_info/static/js/hamburger-menu.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const hamburgerIcon = document.querySelector('.hamburger-icon');
+  const menuItems = document.querySelector('.menu-items');
+  const menuOverlay = document.querySelector('.menu-overlay');
+  const menuCloseBtn = document.querySelector('.menu-close-btn');
+
+  // Function to close the menu
+  function closeMenu() {
+    hamburgerIcon.classList.remove('active');
+    menuItems.classList.remove('active');
+    menuOverlay.classList.remove('active');
+  }
+
+  // Toggle menu when hamburger icon is clicked
+  hamburgerIcon.addEventListener('click', function() {
+    hamburgerIcon.classList.toggle('active');
+    menuItems.classList.toggle('active');
+    menuOverlay.classList.toggle('active');
+  });
+
+  // Close menu when clicking outside
+  menuOverlay.addEventListener('click', closeMenu);
+
+  // Close menu when clicking the close button
+  if (menuCloseBtn) {
+    menuCloseBtn.addEventListener('click', closeMenu);
+  }
+
+  // Close menu when pressing escape key
+  document.addEventListener('keydown', function(event) {
+    if (event.key === 'Escape') {
+      closeMenu();
+    }
+  });
+});

--- a/django/user_info/templates/search.html
+++ b/django/user_info/templates/search.html
@@ -29,6 +29,7 @@
       </div>
       <div class="menu-items">
         <a href="{% url 'tool_list' %}">My Tools</a>
+        <a href="{% url 'apikey_list' %}">My API Keys</a>
         <a href="{% url 'logout' %}">Logout</a>
         <button class="menu-close-btn">Close Menu</button>
       </div>

--- a/django/user_info/templates/search.html
+++ b/django/user_info/templates/search.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
     <link rel="stylesheet" href="{% static 'css/api-integration.css' %}">
+    <link rel="stylesheet" href="{% static 'css/hamburger-menu.css' %}">
   </head>
   <body>
     <div class="s006">
@@ -18,8 +19,20 @@
           </div>
         </a>
       </div>
-      <a href="{% url 'logout' %}" class="btn-logout">Logout</a>
-      <a href="{% url 'tool_list' %}" class="btn-logout" style="right: 150px;">My Tools</a>
+      <!-- Hamburger Menu -->
+      <div class="hamburger-menu">
+        <div class="hamburger-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </div>
+      <div class="menu-items">
+        <a href="{% url 'tool_list' %}">My Tools</a>
+        <a href="{% url 'logout' %}">Logout</a>
+        <button class="menu-close-btn">Close Menu</button>
+      </div>
+      <div class="menu-overlay"></div>
       <div class="search-container">
         <form action="{% url 'search' %}" method="POST">
           {% csrf_token %}
@@ -70,7 +83,8 @@
         </div>
       </div>
     </div>
-  <script>
+  <script src="{% static 'js/hamburger-menu.js' %}"></script>
+<script>
   document.getElementById('search').addEventListener('focus', function() {
     this.value = '';
   });

--- a/django/user_info/templates/search.html
+++ b/django/user_info/templates/search.html
@@ -28,10 +28,10 @@
         </div>
       </div>
       <div class="menu-items">
-        <a href="{% url 'tool_list' %}">My Tools</a>
-        <a href="{% url 'apikey_list' %}">My API Keys</a>
+        <a href="{% url 'tool_list' %}">Tools</a>
+        <a href="{% url 'apikey_list' %}">API Keys</a>
         <a href="{% url 'logout' %}">Logout</a>
-        <button class="menu-close-btn">Close Menu</button>
+        <button class="menu-close-btn">Close</button>
       </div>
       <div class="menu-overlay"></div>
       <div class="search-container">

--- a/django/user_info/templates/search.html
+++ b/django/user_info/templates/search.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Asha Software | Search</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="author" content="colorlib.com">
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />

--- a/django/user_info/templates/user_info/apikey_confirm_delete.html
+++ b/django/user_info/templates/user_info/apikey_confirm_delete.html
@@ -4,28 +4,12 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Delete Tool</title>
+    <title>Delete API Key</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
     <link rel="stylesheet" href="{% static 'css/hamburger-menu.css' %}">
     <style>
-        .nav-links {
-            display: flex;
-            margin-bottom: 20px;
-        }
-        .nav-link {
-            color: white;
-            text-decoration: none;
-            margin-right: 20px;
-        }
-        .nav-link span {
-            border-bottom: 2px solid transparent;
-            padding-bottom: 5px;
-        }
-        .nav-link.active span {
-            border-bottom: 2px solid white;
-        }
         .delete-container {
             max-width: 600px;
             margin: 0 auto;
@@ -37,7 +21,7 @@
             z-index: 1;
             position: relative;
         }
-        .tool-info {
+        .apikey-info {
             margin: 20px 0;
             padding: 15px;
             background-color: rgba(30, 30, 30, 0.9);
@@ -64,9 +48,29 @@
         .text-muted {
             color: #ccc !important;
         }
-        .badge {
-            background-color: rgba(255, 255, 255, 0.2);
-            color: #fff;
+        .key-value {
+            font-family: monospace;
+            background-color: rgba(20, 20, 20, 0.9);
+            padding: 8px;
+            border-radius: 4px;
+            word-break: break-all;
+            margin-top: 10px;
+        }
+        .nav-links {
+            display: flex;
+            margin-bottom: 20px;
+        }
+        .nav-link {
+            color: white;
+            text-decoration: none;
+            margin-right: 20px;
+        }
+        .nav-link span {
+            border-bottom: 2px solid transparent;
+            padding-bottom: 5px;
+        }
+        .nav-link.active span {
+            border-bottom: 2px solid white;
         }
     </style>
 </head>
@@ -88,9 +92,9 @@
             </div>
         </div>
         <div class="menu-items">
-            <a href="{% url 'tool_list' %}">Back to Tools</a>
+            <a href="{% url 'apikey_list' %}">Back to API Keys</a>
             <a href="{% url 'search' %}">Search</a>
-            <a href="{% url 'apikey_list' %}">My API Keys</a>
+            <a href="{% url 'tool_list' %}">My Tools</a>
             <a href="{% url 'logout' %}">Logout</a>
             <button class="menu-close-btn">Close Menu</button>
         </div>
@@ -101,35 +105,39 @@
                 <a href="{% url 'search' %}" class="nav-link">
                     <span>Search</span>
                 </a>
-                <a href="{% url 'tool_list' %}" class="nav-link active">
+                <a href="{% url 'tool_list' %}" class="nav-link">
                     <span>My Tools</span>
                 </a>
-                <a href="{% url 'apikey_list' %}" class="nav-link">
+                <a href="{% url 'apikey_list' %}" class="nav-link active">
                     <span>My API Keys</span>
                 </a>
             </div>
 
-            <h1 class="text-danger mb-4">Delete Tool</h1>
+            <h1 class="text-danger mb-4">Delete API Key</h1>
             
             <div class="alert alert-warning">
                 <h4 class="alert-heading">Warning!</h4>
-                <p>Are you sure you want to delete this tool? This action cannot be undone.</p>
+                <p>Are you sure you want to delete this API key? This action cannot be undone.</p>
+                <p>Any applications or scripts using this API key will no longer be able to access the API.</p>
             </div>
             
-            <div class="tool-info">
-                <h5>{{ tool.name }}</h5>
-                <p class="text-muted">{{ tool.description|default:"No description provided" }}</p>
-                <div>
-                    <span class="badge">{{ tool.method }}</span>
-                    <small class="text-muted ml-2">Created: {{ tool.created_at|date:"M d, Y" }}</small>
+            <div class="apikey-info">
+                <h5>{{ apikey.name }}</h5>
+                <div class="key-value">{{ apikey.key }}</div>
+                <div class="mt-3">
+                    <small class="text-muted">Created: {{ apikey.created_at|date:"M d, Y" }}</small>
+                    {% if apikey.last_used_at %}
+                        <br>
+                        <small class="text-muted">Last used: {{ apikey.last_used_at|date:"M d, Y H:i" }}</small>
+                    {% endif %}
                 </div>
             </div>
             
             <form method="post">
                 {% csrf_token %}
                 <div class="d-flex justify-content-between">
-                    <a href="{% url 'tool_list' %}" class="btn btn-outline-secondary">Cancel</a>
-                    <button type="submit" class="btn btn-danger">Delete Tool</button>
+                    <a href="{% url 'apikey_list' %}" class="btn btn-outline-secondary">Cancel</a>
+                    <button type="submit" class="btn btn-danger">Delete API Key</button>
                 </div>
             </form>
         </div>

--- a/django/user_info/templates/user_info/apikey_confirm_delete.html
+++ b/django/user_info/templates/user_info/apikey_confirm_delete.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Delete API Key</title>
+    <title>Asha Software | Delete API Key</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">

--- a/django/user_info/templates/user_info/apikey_list.html
+++ b/django/user_info/templates/user_info/apikey_list.html
@@ -4,12 +4,91 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Your Tools</title>
+    <title>Your API Keys</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
     <link rel="stylesheet" href="{% static 'css/hamburger-menu.css' %}">
     <style>
+        .apikey-card {
+            margin-bottom: 20px;
+            border-radius: 8px;
+            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+            background: rgba(40, 40, 40, 0.9);
+            color: #fff;
+        }
+        .apikey-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 15px;
+            border-top-left-radius: 8px;
+            border-top-right-radius: 8px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        .apikey-body {
+            padding: 15px;
+        }
+        .apikey-actions {
+            display: flex;
+            gap: 10px;
+        }
+        .btn-apikey {
+            padding: 5px 10px;
+            font-size: 14px;
+        }
+        .apikey-status {
+            display: inline-block;
+            padding: 3px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+        .status-active {
+            background-color: rgba(21, 87, 36, 0.7);
+            color: #fff;
+        }
+        .status-inactive {
+            background-color: rgba(114, 28, 36, 0.7);
+            color: #fff;
+        }
+        .apikeys-container {
+            width: 100%;
+            max-width: 1000px;
+            z-index: 1;
+            position: relative;
+        }
+        .btn-create {
+            background: transparent;
+            color: white;
+            border: 2px solid white;
+            border-radius: 5px;
+            padding: 8px 16px;
+            transition: all 0.3s ease-in-out;
+            margin-bottom: 20px;
+        }
+        .btn-create:hover {
+            background-color: white;
+            color: black;
+        }
+        .text-muted {
+            color: #ccc !important;
+        }
+        .alert-info {
+            background-color: rgba(40, 40, 40, 0.9);
+            color: #fff;
+            border: none;
+        }
+        .alert-info a {
+            color: #4da6ff;
+        }
+        .key-value {
+            font-family: monospace;
+            background-color: rgba(30, 30, 30, 0.9);
+            padding: 8px;
+            border-radius: 4px;
+            word-break: break-all;
+        }
         .nav-links {
             display: flex;
             margin-bottom: 20px;
@@ -25,86 +104,6 @@
         }
         .nav-link.active span {
             border-bottom: 2px solid white;
-        }
-        .tool-card {
-            margin-bottom: 20px;
-            border-radius: 8px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-            background: rgba(40, 40, 40, 0.9);
-            color: #fff;
-        }
-        .tool-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 15px;
-            border-top-left-radius: 8px;
-            border-top-right-radius: 8px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-        }
-        .tool-body {
-            padding: 15px;
-        }
-        .tool-actions {
-            display: flex;
-            gap: 10px;
-        }
-        .btn-tool {
-            padding: 5px 10px;
-            font-size: 14px;
-        }
-        .tool-status {
-            display: inline-block;
-            padding: 3px 8px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: bold;
-        }
-        .status-active {
-            background-color: rgba(21, 87, 36, 0.7);
-            color: #fff;
-        }
-        .status-inactive {
-            background-color: rgba(114, 28, 36, 0.7);
-            color: #fff;
-        }
-        .status-preferred {
-            background-color: rgba(255, 193, 7, 0.7);
-            color: #000;
-            margin-left: 5px;
-        }
-        .tools-container {
-            width: 100%;
-            max-width: 1000px;
-            z-index: 1;
-            position: relative;
-        }
-        .btn-create {
-            background: transparent;
-            color: white;
-            border: 2px solid white;
-            border-radius: 5px;
-            padding: 8px 16px;
-            transition: all 0.3s ease-in-out;
-        }
-        .btn-create:hover {
-            background-color: white;
-            color: black;
-        }
-        .text-muted {
-            color: #ccc !important;
-        }
-        .badge {
-            background-color: rgba(255, 255, 255, 0.2);
-            color: #fff;
-        }
-        .alert-info {
-            background-color: rgba(40, 40, 40, 0.9);
-            color: #fff;
-            border: none;
-        }
-        .alert-info a {
-            color: #4da6ff;
         }
     </style>
 </head>
@@ -134,15 +133,15 @@
         </div>
         <div class="menu-overlay"></div>
         
-        <div class="tools-container">
+        <div class="apikeys-container">
             <div class="nav-links">
                 <a href="{% url 'search' %}" class="nav-link">
                     <span>Search</span>
                 </a>
-                <a href="{% url 'tool_list' %}" class="nav-link active">
+                <a href="{% url 'tool_list' %}" class="nav-link">
                     <span>My Tools</span>
                 </a>
-                <a href="{% url 'apikey_list' %}" class="nav-link">
+                <a href="{% url 'apikey_list' %}" class="nav-link active">
                     <span>My API Keys</span>
                 </a>
             </div>
@@ -155,34 +154,36 @@
                 {% endfor %}
             {% endif %}
 
-            {% if tools %}
+            <form method="post" action="{% url 'apikey_create' %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-create">Create New API Key</button>
+            </form>
+
+            {% if apikeys %}
                 <div class="row">
-                    {% for tool in tools %}
+                    {% for apikey in apikeys %}
                         <div class="col-md-6">
-                            <div class="tool-card">
-                                <div class="tool-header">
-                                    <h5 class="mb-0">{{ tool.name }}</h5>
+                            <div class="apikey-card">
+                                <div class="apikey-header">
+                                    <h5 class="mb-0">{{ apikey.name }}</h5>
                                     <div>
-                                        <span class="tool-status {% if tool.is_active %}status-active{% else %}status-inactive{% endif %}">
-                                            {% if tool.is_active %}Active{% else %}Inactive{% endif %}
+                                        <span class="apikey-status {% if apikey.is_active %}status-active{% else %}status-inactive{% endif %}">
+                                            {% if apikey.is_active %}Active{% else %}Inactive{% endif %}
                                         </span>
-                                        {% if tool.is_preferred %}
-                                        <span class="tool-status status-preferred">
-                                            Preferred
-                                        </span>
-                                        {% endif %}
                                     </div>
                                 </div>
-                                <div class="tool-body">
-                                    <p>{{ tool.description|default:"No description provided" }}</p>
+                                <div class="apikey-body">
+                                    <div class="key-value mb-3">{{ apikey.key }}</div>
                                     <div class="d-flex justify-content-between align-items-center">
                                         <div>
-                                            <span class="badge">{{ tool.method }}</span>
-                                            <small class="text-muted ml-2">Created: {{ tool.created_at|date:"M d, Y" }}</small>
+                                            <small class="text-muted">Created: {{ apikey.created_at|date:"M d, Y" }}</small>
+                                            {% if apikey.last_used_at %}
+                                                <br>
+                                                <small class="text-muted">Last used: {{ apikey.last_used_at|date:"M d, Y H:i" }}</small>
+                                            {% endif %}
                                         </div>
-                                        <div class="tool-actions">
-                                            <a href="{% url 'tool_edit' tool.id %}" class="btn btn-sm btn-outline-light btn-tool">Edit</a>
-                                            <a href="{% url 'tool_delete' tool.id %}" class="btn btn-sm btn-outline-danger btn-tool">Delete</a>
+                                        <div class="apikey-actions">
+                                            <a href="{% url 'apikey_delete' apikey.id %}" class="btn btn-sm btn-outline-danger btn-apikey">Delete</a>
                                         </div>
                                     </div>
                                 </div>
@@ -192,7 +193,7 @@
                 </div>
             {% else %}
                 <div class="alert alert-info">
-                    <p>You haven't created any tools yet. <a href="{% url 'tool_create' %}">Create your first tool</a> to get started!</p>
+                    <p>You haven't created any API keys yet. Click the "Create New API Key" button above to get started!</p>
                 </div>
             {% endif %}
         </div>

--- a/django/user_info/templates/user_info/apikey_list.html
+++ b/django/user_info/templates/user_info/apikey_list.html
@@ -26,9 +26,6 @@
             border-top-right-radius: 8px;
             border-bottom: 1px solid rgba(255, 255, 255, 0.1);
         }
-        .apikey-body {
-            padding: 15px;
-        }
         .apikey-actions {
             display: flex;
             gap: 10px;
@@ -52,7 +49,10 @@
             background-color: rgba(114, 28, 36, 0.7);
             color: #fff;
         }
-        .apikeys-container {
+        .tool-body {
+            padding: 15px;
+        }
+        .tools-container {
             width: 100%;
             max-width: 1000px;
             z-index: 1;
@@ -65,7 +65,6 @@
             border-radius: 5px;
             padding: 8px 16px;
             transition: all 0.3s ease-in-out;
-            margin-bottom: 20px;
         }
         .btn-create:hover {
             background-color: white;
@@ -126,23 +125,23 @@
         </div>
         <div class="menu-items">
             <a href="{% url 'search' %}">Search</a>
-            <a href="{% url 'tool_list' %}">My Tools</a>
-            <a href="{% url 'apikey_list' %}">My API Keys</a>
+            <a href="{% url 'tool_list' %}">Tools</a>
+            <a href="{% url 'apikey_list' %}">API Keys</a>
             <a href="{% url 'logout' %}">Logout</a>
-            <button class="menu-close-btn">Close Menu</button>
+            <button class="menu-close-btn">Close</button>
         </div>
         <div class="menu-overlay"></div>
         
-        <div class="apikeys-container">
+        <div class="tools-container">
             <div class="nav-links">
                 <a href="{% url 'search' %}" class="nav-link">
                     <span>Search</span>
                 </a>
                 <a href="{% url 'tool_list' %}" class="nav-link">
-                    <span>My Tools</span>
+                    <span>Tools</span>
                 </a>
                 <a href="{% url 'apikey_list' %}" class="nav-link active">
-                    <span>My API Keys</span>
+                    <span>API Keys</span>
                 </a>
             </div>
 
@@ -153,11 +152,6 @@
                     </div>
                 {% endfor %}
             {% endif %}
-
-            <form method="post" action="{% url 'apikey_create' %}">
-                {% csrf_token %}
-                <button type="submit" class="btn btn-create">Create New API Key</button>
-            </form>
 
             {% if apikeys %}
                 <div class="row">
@@ -172,7 +166,7 @@
                                         </span>
                                     </div>
                                 </div>
-                                <div class="apikey-body">
+                                <div class="tool-body">
                                     <div class="key-value mb-3">{{ apikey.key }}</div>
                                     <div class="d-flex justify-content-between align-items-center">
                                         <div>
@@ -193,9 +187,14 @@
                 </div>
             {% else %}
                 <div class="alert alert-info">
-                    <p>You haven't created any API keys yet. Click the "Create New API Key" button above to get started!</p>
+                    <p>You haven't created any API keys yet. <a href="{% url 'apikey_create' %}">Create your first API key</a> to get started!</p>
                 </div>
             {% endif %}
+            
+            <form method="post" action="{% url 'apikey_create' %}" style="margin-top: 20px;">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-create">Create New API Key</button>
+            </form>
         </div>
     </div>
 

--- a/django/user_info/templates/user_info/apikey_list.html
+++ b/django/user_info/templates/user_info/apikey_list.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Your API Keys</title>
+    <title>Asha Software | List API Keys</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">

--- a/django/user_info/templates/user_info/tool_confirm_delete.html
+++ b/django/user_info/templates/user_info/tool_confirm_delete.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Delete Tool</title>
+    <title>Asha Software | Delete Tool</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">

--- a/django/user_info/templates/user_info/tool_confirm_delete.html
+++ b/django/user_info/templates/user_info/tool_confirm_delete.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
+    <link rel="stylesheet" href="{% static 'css/hamburger-menu.css' %}">
     <style>
         .delete-container {
             max-width: 600px;
@@ -62,7 +63,21 @@
                 </div>
             </a>
         </div>
-        <a href="{% url 'logout' %}" class="btn-logout">Logout</a>
+        <!-- Hamburger Menu -->
+        <div class="hamburger-menu">
+            <div class="hamburger-icon">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+        </div>
+        <div class="menu-items">
+            <a href="{% url 'tool_list' %}">Back to Tools</a>
+            <a href="{% url 'search' %}">Search</a>
+            <a href="{% url 'logout' %}">Logout</a>
+            <button class="menu-close-btn">Close Menu</button>
+        </div>
+        <div class="menu-overlay"></div>
         
         <div class="delete-container">
             <div style="margin-bottom: 20px;">
@@ -102,5 +117,6 @@
 
     <script src="{% static 'js/jquery.min.js' %}"></script>
     <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
+    <script src="{% static 'js/hamburger-menu.js' %}"></script>
 </body>
 </html>

--- a/django/user_info/templates/user_info/tool_form.html
+++ b/django/user_info/templates/user_info/tool_form.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>{{ title }}</title>
+    <title>Asha Software | {{ title }}</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">

--- a/django/user_info/templates/user_info/tool_form.html
+++ b/django/user_info/templates/user_info/tool_form.html
@@ -59,6 +59,7 @@
             max-width: 1000px;
             z-index: 1;
             position: relative;
+            padding-top: 140px;
         }
         .form-control {
             background-color: rgba(30, 30, 30, 0.9) !important;
@@ -120,9 +121,9 @@
         <div class="menu-items">
             <a href="{% url 'tool_list' %}">Back to Tools</a>
             <a href="{% url 'search' %}">Search</a>
-            <a href="{% url 'apikey_list' %}">My API Keys</a>
+            <a href="{% url 'apikey_list' %}">API Keys</a>
             <a href="{% url 'logout' %}">Logout</a>
-            <button class="menu-close-btn">Close Menu</button>
+            <button class="menu-close-btn">Close</button>
         </div>
         <div class="menu-overlay"></div>
         

--- a/django/user_info/templates/user_info/tool_form.html
+++ b/django/user_info/templates/user_info/tool_form.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
+    <link rel="stylesheet" href="{% static 'css/hamburger-menu.css' %}">
     <style>
         .form-section {
             margin-bottom: 30px;
@@ -92,8 +93,21 @@
                 </div>
             </a>
         </div>
-        <a href="{% url 'logout' %}" class="btn-logout">Logout</a>
-        <a href="{% url 'tool_list' %}" class="btn-logout" style="right: 150px;">Back to Tools</a>
+        <!-- Hamburger Menu -->
+        <div class="hamburger-menu">
+            <div class="hamburger-icon">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+        </div>
+        <div class="menu-items">
+            <a href="{% url 'tool_list' %}">Back to Tools</a>
+            <a href="{% url 'search' %}">Search</a>
+            <a href="{% url 'logout' %}">Logout</a>
+            <button class="menu-close-btn">Close Menu</button>
+        </div>
+        <div class="menu-overlay"></div>
         
         <div class="form-container">
             <div style="margin-bottom: 20px;">
@@ -260,6 +274,7 @@
 
     <script src="{% static 'js/jquery.min.js' %}"></script>
     <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
+    <script src="{% static 'js/hamburger-menu.js' %}"></script>
     <script>
         // Add Bootstrap form classes
         $(document).ready(function() {

--- a/django/user_info/templates/user_info/tool_form.html
+++ b/django/user_info/templates/user_info/tool_form.html
@@ -10,6 +10,22 @@
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
     <link rel="stylesheet" href="{% static 'css/hamburger-menu.css' %}">
     <style>
+        .nav-links {
+            display: flex;
+            margin-bottom: 20px;
+        }
+        .nav-link {
+            color: white;
+            text-decoration: none;
+            margin-right: 20px;
+        }
+        .nav-link span {
+            border-bottom: 2px solid transparent;
+            padding-bottom: 5px;
+        }
+        .nav-link.active span {
+            border-bottom: 2px solid white;
+        }
         .form-section {
             margin-bottom: 30px;
             padding: 20px;
@@ -104,18 +120,22 @@
         <div class="menu-items">
             <a href="{% url 'tool_list' %}">Back to Tools</a>
             <a href="{% url 'search' %}">Search</a>
+            <a href="{% url 'apikey_list' %}">My API Keys</a>
             <a href="{% url 'logout' %}">Logout</a>
             <button class="menu-close-btn">Close Menu</button>
         </div>
         <div class="menu-overlay"></div>
         
         <div class="form-container">
-            <div style="margin-bottom: 20px;">
-                <a href="{% url 'search' %}" style="color: white; text-decoration: none; margin-right: 20px;">
-                    <span style="border-bottom: 2px solid transparent; padding-bottom: 5px;">Search</span>
+            <div class="nav-links">
+                <a href="{% url 'search' %}" class="nav-link">
+                    <span>Search</span>
                 </a>
-                <a href="{% url 'tool_list' %}" style="color: white; text-decoration: none;">
-                    <span style="border-bottom: 2px solid white; padding-bottom: 5px;">My Tools</span>
+                <a href="{% url 'tool_list' %}" class="nav-link active">
+                    <span>My Tools</span>
+                </a>
+                <a href="{% url 'apikey_list' %}" class="nav-link">
+                    <span>My API Keys</span>
                 </a>
             </div>
 

--- a/django/user_info/templates/user_info/tool_list.html
+++ b/django/user_info/templates/user_info/tool_list.html
@@ -127,10 +127,10 @@
         </div>
         <div class="menu-items">
             <a href="{% url 'search' %}">Search</a>
-            <a href="{% url 'tool_list' %}">My Tools</a>
-            <a href="{% url 'apikey_list' %}">My API Keys</a>
+            <a href="{% url 'tool_list' %}">Tools</a>
+            <a href="{% url 'apikey_list' %}">API Keys</a>
             <a href="{% url 'logout' %}">Logout</a>
-            <button class="menu-close-btn">Close Menu</button>
+            <button class="menu-close-btn">Close</button>
         </div>
         <div class="menu-overlay"></div>
         
@@ -140,10 +140,10 @@
                     <span>Search</span>
                 </a>
                 <a href="{% url 'tool_list' %}" class="nav-link active">
-                    <span>My Tools</span>
+                    <span>Tools</span>
                 </a>
                 <a href="{% url 'apikey_list' %}" class="nav-link">
-                    <span>My API Keys</span>
+                    <span>API Keys</span>
                 </a>
             </div>
 
@@ -195,6 +195,8 @@
                     <p>You haven't created any tools yet. <a href="{% url 'tool_create' %}">Create your first tool</a> to get started!</p>
                 </div>
             {% endif %}
+            
+            <a href="{% url 'tool_create' %}" class="btn btn-create" style="margin-top: 20px;">Create New Tool</a>
         </div>
     </div>
 

--- a/django/user_info/templates/user_info/tool_list.html
+++ b/django/user_info/templates/user_info/tool_list.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Your Tools</title>
+    <title>Asha Software | Tools</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">

--- a/django/user_info/templates/user_info/tool_list.html
+++ b/django/user_info/templates/user_info/tool_list.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
+    <link rel="stylesheet" href="{% static 'css/hamburger-menu.css' %}">
     <style>
         .tool-card {
             margin-bottom: 20px;
@@ -100,8 +101,20 @@
                 </div>
             </a>
         </div>
-        <a href="{% url 'logout' %}" class="btn-logout">Logout</a>
-        <a href="{% url 'tool_create' %}" class="btn-logout" style="right: 150px;">Create New Tool</a>
+        <!-- Hamburger Menu -->
+        <div class="hamburger-menu">
+            <div class="hamburger-icon">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+        </div>
+        <div class="menu-items">
+            <a href="{% url 'search' %}">Search</a>
+            <a href="{% url 'logout' %}">Logout</a>
+            <button class="menu-close-btn">Close Menu</button>
+        </div>
+        <div class="menu-overlay"></div>
         
         <div class="tools-container">
             <div style="margin-bottom: 20px;">
@@ -166,5 +179,6 @@
 
     <script src="{% static 'js/jquery.min.js' %}"></script>
     <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
+    <script src="{% static 'js/hamburger-menu.js' %}"></script>
 </body>
 </html>

--- a/django/user_info/urls.py
+++ b/django/user_info/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from .views import register, signin, home, search, logout_view, forgot_password_view
 from .views import tool_list, tool_create, tool_edit, tool_delete
-from .views import get_api_key
+from .views import get_api_key, apikey_list, apikey_create, apikey_delete
 
 urlpatterns = [
     path('', home, name='home'),
@@ -16,6 +16,11 @@ urlpatterns = [
     path('tools/create/', tool_create, name='tool_create'),
     path('tools/<int:tool_id>/edit/', tool_edit, name='tool_edit'),
     path('tools/<int:tool_id>/delete/', tool_delete, name='tool_delete'),
+    
+    # API Key URLs
+    path('apikeys/', apikey_list, name='apikey_list'),
+    path('apikeys/create/', apikey_create, name='apikey_create'),
+    path('apikeys/<int:apikey_id>/delete/', apikey_delete, name='apikey_delete'),
     
     # API endpoints
     path('api/api-keys/', get_api_key, name='get_api_key'),


### PR DESCRIPTION
Besides, API keys are automatically created. I've added a couple of more options

1. Users can now create their own API keys using UI
2. Users can create API keys using API endpoint [1]
3. Users can list their API keys along with delete them
4. All the information is provided in the readme file.

[1]
`curl -X POST \
  http://localhost:8001/api-keys \
  -H 'Content-Type: application/json' \
  -H 'X-API-Key: <api-key>' \
  -d '{"name": "FastAPI"}'`