### PR TITLE
Override proxy config in Dockerfile to avoid bad package hashes

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -2,6 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Configure apt to avoid Hash Sum mismatch
+RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::http::No-Cache true;" >> /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::BrokenProxy    true;" >> /etc/apt/apt.conf.d/99custom
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     default-libmysqlclient-dev \


### PR DESCRIPTION
I ran into [this error](https://github.com/jenkinsci/docker/issues/543) when running `docker compose up`. A bad proxy is causing hash errors when apt-get attempts to install packages in the Dockerfile.

[The fix](https://github.com/jenkinsci/docker/issues/543#issuecomment-2568210821) mentioned in a comment on that issue worked for me.

Error logs:

```
39.88 E: Failed to fetch http://deb.debian.org/debian/pool/main/b/binutils/binutils-common_2.40-2_amd64.deb  Hash Sum mismatch
39.88    Hashes of expected file:
39.88     - SHA256:ab314134f43a0891a48f69a9bc33d825da748fa5e0ba2bebb7a5c491b026f1a0
39.88     - MD5Sum:44fb94480bf76060e6deffe24b196c65 [weak]
39.88     - Filesize:2486664 [weak]
39.88    Hashes of received file:
39.88     - SHA256:b55d738c7834a8d189338a36ddc5e41c051d857862390fd90a928a7ce3e71c97
39.88     - MD5Sum:3ae3034b573d2ea6be1060d72fbb5b8d [weak]
39.88     - Filesize:2486664 [weak]Fetched 104 MB in 36s (2896 kB/s)
39.88 
39.88    Last modification reported: Sun, 15 Jan 2023 09:13:01 +0000
39.88 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
------
failed to solve: process "/bin/sh -c apt-get update     && apt-get install -y     default-libmysqlclient-dev     build-essential     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

Full error log: https://gist.github.com/djsauble/87b4005374643eef26f8878d808bf4eb