### PR TITLE
Fixes for a few Terraform related errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,11 @@ logs/
 tmp/
 temp/
 Thumbs.db
+
+# Secrets
+app-secrets.yaml
+*.pem
+
+# Terraform
+.terraform*
+*.tfstate*

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -25,7 +25,7 @@ Before deploying the application, you need to create the necessary infrastructur
 ```bash
 cd terraform
 terraform init
-terraform apply (optional --auto-aprove)
+terraform apply # --auto-approve
 ```
 
 This will create:

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -138,7 +138,7 @@ cd "$PROJECT_ROOT"
 
 # Get AWS account ID
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --no-cli-pager --query Account --output text)
-AWS_REGION=$(aws configure get region)
+AWS_REGION=us-east-1
 ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 
 # Build Docker images if requested

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -421,7 +421,10 @@ resource "aws_instance" "ollama_instance" {
     }
   )
 
-  depends_on = [aws_internet_gateway.eks_igw]
+  depends_on = [
+    aws_internet_gateway.eks_igw,
+    aws_route_table_association.ollama_public_rt_assoc
+  ]
 }
 
 # Output the path to the Ollama key file

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -72,39 +72,42 @@ resource "aws_security_group" "eks_lb_sg" {
   description = "Security group for EKS cluster load balancers"
   vpc_id      = aws_vpc.eks_vpc.id
 
-  # Allow HTTP traffic for Django (port 8000)
-  ingress {
-    from_port   = 8000
-    to_port     = 8000
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow Django HTTP traffic"
-  }
-
-  # Allow HTTP traffic for API (port 8001)
-  ingress {
-    from_port   = 8001
-    to_port     = 8001
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow API HTTP traffic"
-  }
-
-  # Allow all outbound traffic
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow all outbound traffic"
-  }
-
   tags = merge(
     var.tags,
     {
       Name = "${var.cluster_name}-lb-sg"
     }
   )
+}
+
+resource "aws_security_group_rule" "eks_lb_allow_django" {
+  type              = "ingress"
+  from_port         = 8000
+  to_port           = 8000
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow Django HTTP traffic"
+  security_group_id = aws_security_group.eks_lb_sg.id
+}
+
+resource "aws_security_group_rule" "eks_lb_allow_api" {
+  type              = "ingress"
+  from_port         = 8001
+  to_port           = 8001
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow API HTTP traffic"
+  security_group_id = aws_security_group.eks_lb_sg.id
+}
+
+resource "aws_security_group_rule" "eks_lb_allow_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow all outbound traffic"
+  security_group_id = aws_security_group.eks_lb_sg.id
 }
 
 # Route Table for Public Subnets
@@ -319,39 +322,42 @@ resource "aws_security_group" "ollama_sg" {
   description = "Security group for Ollama EC2 instance"
   vpc_id      = aws_vpc.eks_vpc.id
 
-  # Allow SSH from anywhere (you may want to restrict this to your IP)
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow SSH from anywhere"
-  }
-
-  # Allow Ollama API port from anywhere
-  ingress {
-    from_port   = 11434
-    to_port     = 11434
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow Ollama API access from anywhere"
-  }
-
-  # Allow all outbound traffic
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow all outbound traffic"
-  }
-
   tags = merge(
     var.tags,
     {
       Name = "${var.cluster_name}-ollama-sg"
     }
   )
+}
+
+resource "aws_security_group_rule" "ollama_allow_ssh" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow SSH from anywhere"
+  security_group_id = aws_security_group.ollama_sg.id
+}
+
+resource "aws_security_group_rule" "ollama_allow_api" {
+  type              = "ingress"
+  from_port         = 11434
+  to_port           = 11434
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow Ollama API access from anywhere"
+  security_group_id = aws_security_group.ollama_sg.id
+}
+
+resource "aws_security_group_rule" "ollama_allow_all_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow all outbound traffic"
+  security_group_id = aws_security_group.ollama_sg.id
 }
 
 # IAM Role for Ollama EC2 Instance - Use a unique name to avoid conflicts

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,5 +1,5 @@
 # AWS Region
-aws_region = "us-west-2"
+aws_region = "us-east-1"
 
 # Kubernetes Version
 kubernetes_version = "1.32"
@@ -24,7 +24,7 @@ ssh_key_name = "ollama-key"  # Using the key that was created in the AWS console
 # source_security_group_ids = ["sg-12345678"]
 
 # Ollama EC2 Instance Configuration
-ollama_ami_id = "ami-0c65adc9a5c1b5d7c" # Ubuntu 22.04 LTS in us-west-2, update for your region
+ollama_ami_id = "ami-00ca0754cabb20b45" # Ubuntu 22.04 LTS in us-east-1, update for your region
 ollama_model = "mistral-nemo"
 ollama_instance_name = "ollama-gpu-instance"
 ollama_instance_type = "g4dn.xlarge"  # You can change this to another GPU instance type if needed


### PR DESCRIPTION
PR that fixes a few issues I encountered while testing cloud deployment.

* Standardize defaults on `us-east-1` (including switching the AMI ID to the one for `us-east-1`).
* Break out security group rules into separate Terraform resources to fix dependency errors. 
* Add a few more entries to .gitignore (to keep secrets out of git and to ignore terraform state files).